### PR TITLE
External redis store + scene timeout & chaining

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -33,7 +33,7 @@ module.exports = class Botact {
       }
     })
 
-    this.flow = { scenes: {}, session: {} }
+    this.flow = { scenes: {}, session: {}, timeout: settings.flowTimeout }
     this.actions = { commands: [], hears: [], events: [], middlewares: [] }
     this.methods = { user: {}, group: {} }
     this.settings = settings

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,3 +1,5 @@
+const redis = require('redis')
+
 module.exports = class Botact {
   constructor (settings) {
     if (!(settings.confirmation && settings.token)) {
@@ -35,6 +37,7 @@ module.exports = class Botact {
     this.actions = { commands: [], hears: [], events: [], middlewares: [] }
     this.methods = { user: {}, group: {} }
     this.settings = settings
+    this.redis = settings.redisConfig ? redis.createClient(settings.redisConfig) : redis.createClient()
 
     setInterval(() => {
       const requests = Object.keys(this.methods).map((key, i) => {

--- a/lib/methods/command.js
+++ b/lib/methods/command.js
@@ -2,6 +2,8 @@ module.exports = function (command, callback) {
   const { commands } = this.actions
   const list = typeof command === 'object' ? command : [ command ]
   const string = list.map(item => item.toString().toLowerCase()).join(';')
-  
+
   commands[string] = callback
+
+  return this
 }

--- a/lib/methods/event.js
+++ b/lib/methods/event.js
@@ -4,4 +4,6 @@ module.exports = function (event, callback) {
   events.forEach((event) => {
     this.actions.events[event] = callback
   })
+
+  return this
 }

--- a/lib/methods/flow/add.js
+++ b/lib/methods/flow/add.js
@@ -1,4 +1,6 @@
 module.exports = function (scene, ...callbacks) {
   this.flow.scenes[scene] = callbacks.length === 1 && typeof callbacks[0] === 'object'
     ? callbacks[0] : callbacks
+
+  return this
 }

--- a/lib/methods/flow/join.js
+++ b/lib/methods/flow/join.js
@@ -1,7 +1,5 @@
-const redis = require('redis')
-const client = redis.createClient()
-
 module.exports = async function (ctx, scene, body, step = 0) {
+  const { redisFlowTimeout } = this.settings;
   const { user_id } = ctx
   const { [scene]: callbacks } = this.flow.scenes
   const callback = callbacks[step]
@@ -12,8 +10,11 @@ module.exports = async function (ctx, scene, body, step = 0) {
       step,
       session: body
     }
-    
-    await client.set(`flow:${user_id}`, JSON.stringify(settings))
+
+    redisFlowTimeout ?
+      await this.redis.set(`flow:${user_id}`, JSON.stringify(settings), 'EX', redisFlowTimeout) :
+      await this.redis.set(`flow:${user_id}`, JSON.stringify(settings))
+
     
     return callback({
       ...ctx,

--- a/lib/methods/flow/join.js
+++ b/lib/methods/flow/join.js
@@ -1,5 +1,5 @@
 module.exports = async function (ctx, scene, body, step = 0) {
-  const { redisFlowTimeout } = this.settings;
+  const { timeout } = this.flow;
   const { user_id } = ctx
   const { [scene]: callbacks } = this.flow.scenes
   const callback = callbacks[step]
@@ -11,8 +11,8 @@ module.exports = async function (ctx, scene, body, step = 0) {
       session: body
     }
 
-    redisFlowTimeout ?
-      await this.redis.set(`flow:${user_id}`, JSON.stringify(settings), 'EX', redisFlowTimeout) :
+    timeout ?
+      await this.redis.set(`flow:${user_id}`, JSON.stringify(settings), 'EX', timeout) :
       await this.redis.set(`flow:${user_id}`, JSON.stringify(settings))
 
     

--- a/lib/methods/flow/join.js
+++ b/lib/methods/flow/join.js
@@ -1,7 +1,7 @@
 module.exports = async function (ctx, scene, body, step = 0) {
-  const { timeout } = this.flow;
-  const { user_id } = ctx
-  const { [scene]: callbacks } = this.flow.scenes
+  const { user_id, flow, redis } = ctx
+  const { timeout } = flow;
+  const { [scene]: callbacks } = flow.scenes
   const callback = callbacks[step]
   
   try {
@@ -12,8 +12,8 @@ module.exports = async function (ctx, scene, body, step = 0) {
     }
 
     timeout ?
-      await this.redis.set(`flow:${user_id}`, JSON.stringify(settings), 'EX', timeout) :
-      await this.redis.set(`flow:${user_id}`, JSON.stringify(settings))
+      await redis.set(`flow:${user_id}`, JSON.stringify(settings), 'EX', timeout) :
+      await redis.set(`flow:${user_id}`, JSON.stringify(settings))
 
     
     return callback({

--- a/lib/methods/flow/leave.js
+++ b/lib/methods/flow/leave.js
@@ -1,9 +1,6 @@
-const redis = require('redis')
-const client = redis.createClient()
-
 module.exports = async ({ user_id }) => {
   try {
-    return await client.del(`flow:${user_id}`)
+    return await this.redis.del(`flow:${user_id}`)
   } catch (err) {
     return console.error(err)
   }

--- a/lib/methods/flow/leave.js
+++ b/lib/methods/flow/leave.js
@@ -1,6 +1,6 @@
-module.exports = async ({ user_id }) => {
+module.exports = async ({ redis, user_id }) => {
   try {
-    return await this.redis.del(`flow:${user_id}`)
+    return await redis.del(`flow:${user_id}`)
   } catch (err) {
     return console.error(err)
   }

--- a/lib/methods/flow/next.js
+++ b/lib/methods/flow/next.js
@@ -1,5 +1,5 @@
 module.exports = async ({ user_id }, body) => {
-  const { redisFlowTimeout } = this.settings
+  const { timeout } = this.flow;
   try {
     const { scene, step, body: session } = await (() => {
       return new Promise((resolve, reject) => {
@@ -22,8 +22,8 @@ module.exports = async ({ user_id }, body) => {
       }
     }
 
-    return redisFlowTimeout ?
-      await this.redis.set(`flow:${user_id}`, JSON.stringify(settings), 'EX', redisFlowTimeout) :
+    return timeout ?
+      await this.redis.set(`flow:${user_id}`, JSON.stringify(settings), 'EX', timeout) :
       await this.redis.set(`flow:${user_id}`, JSON.stringify(settings))
   } catch (err) {
     return console.error(err)

--- a/lib/methods/flow/next.js
+++ b/lib/methods/flow/next.js
@@ -1,9 +1,9 @@
-module.exports = async ({ user_id }, body) => {
-  const { timeout } = this.flow;
+module.exports = async ({ user_id, redis, flow }, body) => {
+  const { timeout } = flow;
   try {
     const { scene, step, body: session } = await (() => {
       return new Promise((resolve, reject) => {
-        return this.redis.get(`flow:${user_id}`, (err, reply) => {
+        return redis.get(`flow:${user_id}`, (err, reply) => {
           if (err) {
             reject(err)
           } else {
@@ -23,8 +23,8 @@ module.exports = async ({ user_id }, body) => {
     }
 
     return timeout ?
-      await this.redis.set(`flow:${user_id}`, JSON.stringify(settings), 'EX', timeout) :
-      await this.redis.set(`flow:${user_id}`, JSON.stringify(settings))
+      await redis.set(`flow:${user_id}`, JSON.stringify(settings), 'EX', timeout) :
+      await redis.set(`flow:${user_id}`, JSON.stringify(settings))
   } catch (err) {
     return console.error(err)
   }

--- a/lib/methods/flow/next.js
+++ b/lib/methods/flow/next.js
@@ -1,11 +1,9 @@
-const redis = require('redis')
-const client = redis.createClient()
-
 module.exports = async ({ user_id }, body) => {
+  const { redisFlowTimeout } = this.settings
   try {
     const { scene, step, body: session } = await (() => {
       return new Promise((resolve, reject) => {
-        return client.get(`flow:${user_id}`, (err, reply) => {
+        return this.redis.get(`flow:${user_id}`, (err, reply) => {
           if (err) {
             reject(err)
           } else {
@@ -14,15 +12,19 @@ module.exports = async ({ user_id }, body) => {
         })
       })
     })()
-    
-    return await client.set(`flow:${user_id}`, JSON.stringify({
+
+    const settings = {
       scene,
       step: step + 1,
       session: {
         ...session,
         ...body
       }
-    }))
+    }
+
+    return redisFlowTimeout ?
+      await this.redis.set(`flow:${user_id}`, JSON.stringify(settings), 'EX', redisFlowTimeout) :
+      await this.redis.set(`flow:${user_id}`, JSON.stringify(settings))
   } catch (err) {
     return console.error(err)
   }

--- a/lib/methods/handler.js
+++ b/lib/methods/handler.js
@@ -1,6 +1,3 @@
-const redis = require('redis')
-const client = redis.createClient()
-
 module.exports = async function (ctx) {
   try {
     const { user_id, body, scene } = ctx
@@ -8,7 +5,7 @@ module.exports = async function (ctx) {
     
     const flow = await (() => {
       return new Promise((resolve, reject) => {
-        return client.get(`flow:${user_id}`, (err, reply) => {
+        return this.redis.get(`flow:${user_id}`, (err, reply) => {
           if (err) {
             reject(err)
           } else {

--- a/lib/methods/hears.js
+++ b/lib/methods/hears.js
@@ -1,7 +1,9 @@
 module.exports = function (command, callback) {
   const { hears } = this.actions
-  const list = typeof command === 'object' ? command : [ command ]
+  const list = typeof command === 'object' ? command : [command]
   const string = list.map(item => item.toString().toLowerCase()).join(';')
-  
+
   hears[string] = callback
+
+  return this
 }


### PR DESCRIPTION
### Added

- External configurable redis store 
```javascript
new Botact({
    ...
    redisConfig: {options}
})
```
Available options - from  [node-redis](https://github.com/NodeRedis/node_redis#rediscreateclient)  
  

- Scene (session/flow) timeout (in seconds)
```javascript
new Botact({
    ...
    flowTimeout: 20
})
```

- Methods chaining
```javascript
bot.command(...).command(...).hears(...)
```




