### PR TITLE
uploadCover error catch fix

### DIFF
--- a/lib/methods/upload/cover.js
+++ b/lib/methods/upload/cover.js
@@ -45,6 +45,6 @@ module.exports = async function (file, settings) {
 
     return response
   } catch (err) {
-    throw err
+    throw JSON.stringify(err)
   }
 }


### PR DESCRIPTION
When an error occurred, method threw object and it was hard to understand what the error was without the server's response.