### PR TITLE
add next() function to middleware

### DIFF
--- a/lib/methods/listen.js
+++ b/lib/methods/listen.js
@@ -44,7 +44,11 @@ module.exports = async function (req, res) {
 
   if (middlewares.length) {
     try {
-      await Promise.all(middlewares.map(callback => callback(ctx)))
+      await Promise.all(middlewares.map((callback, i) => {
+        const next = middlewares[i + 1] || console.error.bind(console, 'No next middleware provided')
+
+        return callback(ctx, next)
+      }))
     } catch (error) {
       throw new Error(JSON.stringify(error))
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botact",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Botact enables developers to focus on writing reusable application logic instead of spending time building infrastructure.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Думаю, стоит добавить вызов следующего middleware, который можно будет вызывать через await (на манер koa.js). Например, для логирования и замеров производительности.

С официального сайта (koajs.com):
```javascript
app.use(async (ctx, next) => {
  const start = Date.now();
  await next();
  const ms = Date.now() - start;
  ctx.set('X-Response-Time', `${ms}ms`);
});
```

Моя текущая реализация работает только для других middleware, то есть сами методы Botact через next() вызвать нельзя. Нужно подумать, как это можно реализовать, потому что сейчас middlewares и методы связаны только контекстом.